### PR TITLE
Fix ShellCheck SC2163 warning on indirect export

### DIFF
--- a/tf
+++ b/tf
@@ -94,7 +94,7 @@ if [[ -f "${REPO_ROOT}/.env" ]]; then
         value="${value:1:${#value}-2}"
       fi
       printf -v "${key}" '%s' "${value}"
-      # shellcheck disable=SC2163 -- indirect export: key holds the variable name
+      # shellcheck disable=SC2163
       export "${key}"
     fi
   done < "${REPO_ROOT}/.env"


### PR DESCRIPTION
## Summary
- Adds `# shellcheck disable=SC2163` directive to `tf:97` for the intentional indirect `export "${key}"` pattern
- Fixes failing CI: https://github.com/ng/terraform-wrapper/actions/runs/23079525946

## Test plan
- [x] `bash -n tf` passes
- [x] `bash tests/tf_test.sh` passes (3/3)
- [ ] CI ShellCheck job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified comments around environment-variable export handling to improve maintainability and silence linter warnings; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->